### PR TITLE
Add external annotation export/import

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -1167,9 +1167,7 @@ const PDFViewerApplication = {
     };
 
     return loadingTask.promise.then(
-      pdfDocument => {
-        this.load(pdfDocument);
-      },
+      pdfDocument => this.load(pdfDocument),
       reason => {
         if (loadingTask !== this.pdfLoadingTask) {
           return undefined; // Ignore errors for previously opened PDF files.
@@ -1249,6 +1247,28 @@ const PDFViewerApplication = {
     classList.remove("wait");
   },
 
+  async exportAnnotations() {
+    const { map } = this.pdfDocument?.annotationStorage.serializable || {};
+    if (!map) {
+      return;
+    }
+    const obj = Object.fromEntries(map);
+    for (const value of Object.values(obj)) {
+      for (const [k, v] of Object.entries(value)) {
+        if (ArrayBuffer.isView(v)) {
+          value[k] = Array.from(v);
+        }
+      }
+    }
+    const json = JSON.stringify(obj);
+    await this.store?.set("annotations", json);
+    this.downloadManager.downloadData(
+      json,
+      this._docFilename.replace(/\.pdf$/i, "_annotations.json"),
+      "application/json"
+    );
+  },
+
   /**
    * Report the error; used for errors affecting loading and/or parsing of
    * the entire PDF document.
@@ -1323,7 +1343,7 @@ const PDFViewerApplication = {
     }
   },
 
-  load(pdfDocument) {
+  async load(pdfDocument) {
     this.pdfDocument = pdfDocument;
 
     pdfDocument.getDownloadInfo().then(({ length }) => {
@@ -1363,15 +1383,16 @@ const PDFViewerApplication = {
     }
     this.pdfDocumentProperties?.setDocument(pdfDocument);
 
+    this.store = new ViewHistory(pdfDocument.fingerprints[0]);
+    await this._loadAnnotationsFromStorage(pdfDocument);
+
     const pdfViewer = this.pdfViewer;
     pdfViewer.setDocument(pdfDocument);
     const { firstPagePromise, onePageRendered, pagesPromise } = pdfViewer;
 
     this.pdfThumbnailViewer?.setDocument(pdfDocument);
 
-    const storedPromise = (this.store = new ViewHistory(
-      pdfDocument.fingerprints[0]
-    ))
+    const storedPromise = this.store
       .getMultiple({
         page: null,
         zoom: DEFAULT_SCALE_VALUE,
@@ -1798,6 +1819,21 @@ const PDFViewerApplication = {
     };
   },
 
+  async _loadAnnotationsFromStorage(pdfDocument) {
+    const json = await this.store?.get("annotations", null);
+    if (!json) {
+      return;
+    }
+    try {
+      const data = JSON.parse(json);
+      for (const [id, value] of Object.entries(data)) {
+        pdfDocument.annotationStorage.setValue(id, value);
+      }
+    } catch (ex) {
+      console.error("Failed to parse annotations", ex);
+    }
+  },
+
   setInitialView(
     storedHash,
     { rotation, sidebarView, scrollMode, spreadMode } = {}
@@ -2003,6 +2039,7 @@ const PDFViewerApplication = {
     );
     eventBus._on("print", this.triggerPrinting.bind(this), opts);
     eventBus._on("download", this.downloadOrSave.bind(this), opts);
+    eventBus._on("exportannotations", this.exportAnnotations.bind(this), opts);
     eventBus._on("firstpage", () => (this.page = 1), opts);
     eventBus._on("lastpage", () => (this.page = this.pagesCount), opts);
     eventBus._on("nextpage", () => pdfViewer.nextPage(), opts);

--- a/web/secondary_toolbar.js
+++ b/web/secondary_toolbar.js
@@ -35,6 +35,7 @@ import { PagesCountLimit } from "./pdf_viewer.js";
  * @property {HTMLButtonElement} printButton - Button to print the document.
  * @property {HTMLButtonElement} downloadButton - Button to download the
  *   document.
+ * @property {HTMLButtonElement} exportAnnotationsButton - Button to export annotations.
  * @property {HTMLAnchorElement} viewBookmarkButton - Button to obtain a
  *   bookmark link to the current location in the document.
  * @property {HTMLButtonElement} firstPageButton - Button to go to the first
@@ -72,6 +73,11 @@ class SecondaryToolbar {
       },
       { element: options.printButton, eventName: "print", close: true },
       { element: options.downloadButton, eventName: "download", close: true },
+      {
+        element: options.exportAnnotationsButton,
+        eventName: "exportannotations",
+        close: true,
+      },
       { element: options.viewBookmarkButton, eventName: null, close: true },
       { element: options.firstPageButton, eventName: "firstpage", close: true },
       { element: options.lastPageButton, eventName: "lastpage", close: true },

--- a/web/toolbar.js
+++ b/web/toolbar.js
@@ -41,6 +41,7 @@ import {
  * @property {HTMLButtonElement} editorFreeTextButton - Button to switch to
  *   FreeText editing.
  * @property {HTMLButtonElement} download - Button to download the document.
+ * @property {HTMLButtonElement} exportAnnotations - Button to export annotations.
  */
 
 class Toolbar {
@@ -67,6 +68,7 @@ class Toolbar {
       { element: options.zoomOut, eventName: "zoomout" },
       { element: options.print, eventName: "print" },
       { element: options.download, eventName: "download" },
+      { element: options.exportAnnotations, eventName: "exportannotations" },
       {
         element: options.editorFreeTextButton,
         eventName: "switchannotationeditormode",

--- a/web/viewer.html
+++ b/web/viewer.html
@@ -344,6 +344,9 @@ See https://github.com/adobe-type-tools/cmap-resources
                   <button id="downloadButton" class="toolbarButton" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
                     <span data-l10n-id="pdfjs-save-button-label"></span>
                   </button>
+                  <button id="exportAnnotations" class="toolbarButton" type="button">
+                    Export Annotations
+                  </button>
                 </div>
 
                 <div class="verticalToolbarSeparator hiddenMediumView"></div>
@@ -367,6 +370,9 @@ See https://github.com/adobe-type-tools/cmap-resources
 
                         <button id="secondaryDownload" class="toolbarButton labeled" type="button" tabindex="0" data-l10n-id="pdfjs-save-button">
                           <span data-l10n-id="pdfjs-save-button-label"></span>
+                        </button>
+                        <button id="secondaryExportAnnotations" class="toolbarButton labeled" type="button">
+                          Export Annotations
                         </button>
 
 <!--#if !GENERIC-->

--- a/web/viewer.js
+++ b/web/viewer.js
@@ -67,6 +67,7 @@ function getViewerConfiguration() {
         "editorSignatureParamsToolbar"
       ),
       download: document.getElementById("downloadButton"),
+      exportAnnotations: document.getElementById("exportAnnotations"),
     },
     secondaryToolbar: {
       toolbar: document.getElementById("secondaryToolbar"),
@@ -78,6 +79,9 @@ function getViewerConfiguration() {
           : null,
       printButton: document.getElementById("secondaryPrint"),
       downloadButton: document.getElementById("secondaryDownload"),
+      exportAnnotationsButton: document.getElementById(
+        "secondaryExportAnnotations"
+      ),
       viewBookmarkButton: document.getElementById("viewBookmark"),
       firstPageButton: document.getElementById("firstPage"),
       lastPageButton: document.getElementById("lastPage"),


### PR DESCRIPTION
## Summary
- add button for exporting annotations
- handle `exportannotations` events in toolbars
- persist annotations using ViewHistory
- load stored annotations when opening a PDF
- format viewer and secondary toolbar files

## Testing
- `npm ci` *(fails: Got status code 403)*
- `npx gulp lint` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_e_686bf41f0c4c83299771a951ee2d206f